### PR TITLE
upgrade rabbitmq, redis, celery and postgresql versions

### DIFF
--- a/mayan-dockers/docker-compose.yml
+++ b/mayan-dockers/docker-compose.yml
@@ -9,7 +9,7 @@ x-mayan-container:
     MAYAN_LOCK_MANAGER_BACKEND_ARGUMENTS: "{'redis_url':'redis://:${MAYAN_REDIS_PASSWORD:-mayanredispassword}@${MAYAN_DOCKER_REDIS_HOSTNAME:-redis}:${MAYAN_DOCKER_REDIS_PORT:-6379}/${MAYAN_REDIS_LOCK_MANAGER_DATABASE:-2}'}"
     # SEARCH_BACKEND_ARGUMENTS: '{"client_hosts": ["http://elastic:${MAYAN_ELASTICSEARCH_PASSWORD:-mayanespassword}@127.0.0.1:9200"]}'
     MAYAN_SEARCH_BACKEND_ARGUMENTS: '{"client_hosts": ["http://${MAYAN_ELASTICSEARCH_USER:-elastic}:${MAYAN_ELASTICSEARCH_PASSWORD:-mayanespassword}@elasticsearch:9200"]}'
-  image: ${MAYAN_DOCKER_IMAGE_NAME:-karmadocksthings/mayanedms-elasticsearch-with-tibetan-analyzer}:${MAYAN_DOCKER_IMAGE_TAG:-0.0.2}
+  image: ${MAYAN_DOCKER_IMAGE_NAME:-karmadocksthings/mayanedms-elasticsearch-with-tibetan-analyzer}:${MAYAN_DOCKER_IMAGE_TAG:-0.0.3}
   logging:
     driver: "json-file"
     options:
@@ -132,7 +132,7 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
-    image: ${MAYAN_DOCKER_POSTGRESQL_IMAGE:-postgres}:${MAYAN_DOCKER_POSTGRESQL_TAG:-14.15-alpine3.21}
+    image: ${MAYAN_DOCKER_POSTGRESQL_IMAGE:-postgres}:${MAYAN_DOCKER_POSTGRESQL_TAG:-14.19}
     networks:
       - mayan
     # Enable to allow external access to the database.
@@ -159,7 +159,7 @@ services:
       PGHOST: ${MAYAN_DATABASE_HOST:-postgresql}
       PGPASSWORD: ${MAYAN_DATABASE_PASSWORD:-mayandbpass}
       PGUSER: ${MAYAN_DATABASE_USER:-mayan}
-    image: ${MAYAN_DOCKER_POSTGRESQL_IMAGE:-postgres}:${MAYAN_DOCKER_POSTGRESQL_TAG:-14.15-alpine3.21}
+    image: ${MAYAN_DOCKER_POSTGRESQL_IMAGE:-postgres}:${MAYAN_DOCKER_POSTGRESQL_TAG:-14.19}
     networks:
       - mayan
     profiles:
@@ -175,7 +175,7 @@ services:
       RABBITMQ_DEFAULT_VHOST: ${MAYAN_RABBITMQ_VHOST:-mayan}
       RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: ${MAYAN_RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS:--rabbit consumer_timeout ${MAYAN_RABBITMQ_CONSUMER_TIMEOUT:-1800000}}
     hostname: ${MAYAN_DOCKER_RABBITMQ_HOSTNAME:-rabbitmq}
-    image: ${MAYAN_DOCKER_RABBITMQ_IMAGE:-rabbitmq}:${MAYAN_DOCKER_RABBITMQ_TAG:-4.0.5-management-alpine}
+    image: ${MAYAN_DOCKER_RABBITMQ_IMAGE:-rabbitmq}:${MAYAN_DOCKER_RABBITMQ_TAG:-4.1.3}
     labels:
       - "traefik.enable=${MAYAN_TRAEFIK_RABBITMQ_ENABLE:-false}"
       - "traefik.http.routers.rabbitmq_admin_http.entrypoints=rabbitmq_admin_http"
@@ -189,8 +189,8 @@ services:
     # Enable the first port to allow access to the administration interface.
     # Enable the second port to allow external access to the data.
     # ports:
-    #   - "${MAYAN_RABBITMQ_ADMIN_PORT:-15672}:15672"
-    #   - "5672:5672"
+      # - "${MAYAN_RABBITMQ_ADMIN_PORT:-15672}:15672"
+      # - "5672:5672"
     profiles:
       - rabbitmq
     restart: unless-stopped
@@ -216,7 +216,7 @@ services:
       - "256"
       - --requirepass
       - "${MAYAN_REDIS_PASSWORD:-mayanredispassword}"
-    image: ${MAYAN_DOCKER_REDIS_IMAGE:-redis}:${MAYAN_DOCKER_REDIS_TAG:-7.4.1-alpine3.20}
+    image: ${MAYAN_DOCKER_REDIS_IMAGE:-redis}:${MAYAN_DOCKER_REDIS_TAG:-8.2.1}
     networks:
       - mayan
     profiles:


### PR DESCRIPTION
Upgraded following libs:

1. Rabbit version from 4.0.5 to 4.1.3
2. Redis version from 7.4.1-alpine3.20 to 8.2.1
3. mayanedms-elasticsearch-with-tibetan-analyzer from 0.0.2 to 0.0.3
4. PostgreSql from 14.15-alpine3.21 to 14.19